### PR TITLE
Add hierarchical repository tree view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ qt_add_qml_module(appGitGenius
         qml/RepositoryHeader.qml
         qml/StatusList.qml
         qml/SubmoduleList.qml
+        qml/RepositoryTreeNode.qml
+        qml/RepositoryTreeView.qml
         qml/GitCommandDialog.qml
     RESOURCES
         assets/icons/repository.svg

--- a/qml/RepositoryTreeNode.qml
+++ b/qml/RepositoryTreeNode.qml
@@ -1,0 +1,82 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+ColumnLayout {
+    id: root
+    property var nodeData: ({})
+    property int depth: 0
+    property bool expanded: depth === 0
+
+    Layout.fillWidth: true
+    width: parent ? parent.width : implicitWidth
+    spacing: 2
+
+    RowLayout {
+        id: headerRow
+        Layout.fillWidth: true
+        spacing: 6
+        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+        Layout.margins: 4
+
+        Item {
+            Layout.preferredWidth: depth * 16
+            Layout.minimumWidth: depth * 16
+            Layout.maximumWidth: depth * 16
+            Layout.fillHeight: true
+        }
+
+        ToolButton {
+            id: toggleButton
+            visible: nodeData.children && nodeData.children.length > 0
+            text: expanded ? "\u25BC" : "\u25B6"
+            onClicked: expanded = !expanded
+            Accessible.name: expanded ? qsTr("Collapse") : qsTr("Expand")
+        }
+
+        Label {
+            text: nodeData.name || qsTr("Repository")
+            font.bold: depth === 0
+            Layout.fillWidth: true
+            elide: Label.ElideRight
+        }
+
+        Label {
+            visible: !!(nodeData.commit)
+            text: nodeData.commit ? nodeData.commit.substr(0, 7) : ""
+            font.family: "monospace"
+            color: palette.placeholderText
+        }
+
+        Label {
+            text: nodeData.status || ""
+            visible: text.length > 0
+            color: (nodeData.symbol && nodeData.symbol !== "") ? "#ff9800" : palette.text
+        }
+
+        Label {
+            text: nodeData.details || ""
+            visible: text.length > 0
+            color: palette.placeholderText
+            elide: Label.ElideRight
+            Layout.preferredWidth: 200
+        }
+    }
+
+    Column {
+        id: childrenContainer
+        Layout.fillWidth: true
+        Layout.preferredHeight: visible ? implicitHeight : 0
+        spacing: 2
+        visible: expanded && nodeData.children && nodeData.children.length > 0
+
+        Repeater {
+            model: nodeData.children || []
+            delegate: RepositoryTreeNode {
+                Layout.fillWidth: true
+                nodeData: modelData
+                depth: root.depth + 1
+            }
+        }
+    }
+}

--- a/qml/RepositoryTreeView.qml
+++ b/qml/RepositoryTreeView.qml
@@ -1,0 +1,49 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Frame {
+    id: root
+    property var treeModel: ({})
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 8
+
+        Label {
+            text: qsTr("Repository tree")
+            font.bold: true
+            Layout.fillWidth: true
+        }
+
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            Column {
+                id: treeContent
+                width: parent ? parent.width : implicitWidth
+                spacing: 4
+
+                RepositoryTreeNode {
+                    id: rootNode
+                    visible: treeModel && treeModel.name
+                    nodeData: treeModel
+                    depth: 0
+                    Layout.fillWidth: true
+                }
+
+                Label {
+                    Layout.fillWidth: true
+                    visible: !rootNode.visible
+                    text: qsTr("Select a repository to view its submodules.")
+                    horizontalAlignment: Text.AlignHCenter
+                    color: palette.placeholderText
+                    padding: 12
+                    wrapMode: Text.Wrap
+                }
+            }
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -82,10 +82,10 @@ ApplicationWindow {
             onStageRequested: function(path) { gitBackend.stageFiles([path]) }
         }
 
-        SubmoduleList {
+        RepositoryTreeView {
             Layout.fillWidth: true
-            Layout.preferredHeight: 260
-            submoduleModel: gitBackend.submodules
+            Layout.preferredHeight: 280
+            treeModel: gitBackend.repositoryTree
         }
 
         RowLayout {

--- a/src/gitclientbackend.h
+++ b/src/gitclientbackend.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVariantList>
+#include <QVariantMap>
 
 struct GitCommandResult
 {
@@ -19,6 +20,7 @@ class GitClientBackend : public QObject
     Q_PROPERTY(QString repositoryPath READ repositoryPath NOTIFY repositoryPathChanged FINAL)
     Q_PROPERTY(QVariantList status READ status NOTIFY statusChanged FINAL)
     Q_PROPERTY(QVariantList submodules READ submodules NOTIFY submodulesChanged FINAL)
+    Q_PROPERTY(QVariantMap repositoryTree READ repositoryTree NOTIFY repositoryTreeChanged FINAL)
 
 public:
     explicit GitClientBackend(QObject *parent = nullptr);
@@ -26,6 +28,7 @@ public:
     QString repositoryPath() const;
     QVariantList status() const;
     QVariantList submodules() const;
+    QVariantMap repositoryTree() const;
 
     Q_INVOKABLE bool openRepository(const QString &path);
     Q_INVOKABLE void refreshRepository();
@@ -37,6 +40,7 @@ signals:
     void repositoryPathChanged();
     void statusChanged();
     void submodulesChanged();
+    void repositoryTreeChanged();
     void commandExecuted(const QVariantMap &result);
 
 private:
@@ -47,4 +51,5 @@ private:
     QString m_repositoryPath;
     QVariantList m_status;
     QVariantList m_submodules;
+    QVariantMap m_repositoryTree;
 };


### PR DESCRIPTION
## Summary
- expose a hierarchical repository tree from the backend so nested submodules can be represented
- add reusable QML components to render the repository tree with collapsible nodes
- replace the flat submodule list with the new tree view in the main window

## Testing
- cmake -S . -B build *(fails: Qt6 SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2c92d43c83228097ef7282733a8d