### PR TITLE
Bind submodule list to backend data

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -72,10 +72,10 @@ ApplicationWindow {
             onStageRequested: function(path) { gitBackend.stageFiles([path]) }
         }
 
-        RepositoryTreeView {
+        SubmoduleList {
             Layout.fillWidth: true
             Layout.preferredHeight: 280
-            treeModel: gitBackend.repositoryTree
+            submoduleModel: gitBackend.submodules
         }
 
         RowLayout {


### PR DESCRIPTION
## Summary
- replace the repository tree view with the submodule list component
- bind the list to `gitBackend.submodules` so subrepositories are rendered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de3d682d948322be2cd2cbe8e0dc64