### PR TITLE
Refine submodule list into colored tile panel

### DIFF
--- a/qml/SubmoduleList.qml
+++ b/qml/SubmoduleList.qml
@@ -172,90 +172,91 @@ Frame {
                     anchors.fill: parent
                     anchors.margins: 12
                     spacing: 12
-                    implicitHeight: childrenRect.height
+                    //implicitHeight: childrenRect.height
 
                     Repeater {
                         model: submoduleModel
 
                         delegate: Item {
-                        width: root.cardSize
-                        height: root.cardSize
+                            width: root.cardSize
+                            height: root.cardSize
 
-                        readonly property string repoName: modelData.name || modelData.path || modelData.raw || ""
-                        readonly property string displayName: root.leafName(repoName)
-                        readonly property color baseColor: root.colorFromString(displayName || repoName)
-                        readonly property string abbrev: root.abbreviationForName(displayName || repoName, 5)
+                            readonly property string repoName: modelData.name || modelData.path || modelData.raw || ""
+                            readonly property string displayName: root.leafName(repoName)
+                            readonly property color baseColor: root.colorFromString(displayName || repoName)
+                            readonly property string abbrev: root.abbreviationForName(displayName || repoName, 5)
 
-                        Rectangle {
-                            anchors.fill: parent
-                            radius: 12
-                            color: baseColor
-                            border.color: Qt.darker(baseColor, 1.2)
-                            border.width: 1
-
-                            Column {
-                                anchors.centerIn: parent
-                                width: parent.width - 24
-                                spacing: 6
-
-                                Label {
-                                    text: abbrev
-                                    font.bold: true
-                                    font.pixelSize: 28
-                                    color: root.textColorForBackground(baseColor, false)
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    width: parent.width
-                                }
-
-                                Label {
-                                    text: displayName
-                                    font.pixelSize: 12
-                                    wrapMode: Label.WordWrap
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: root.textColorForBackground(baseColor, true)
-                                }
-
-                                Label {
-                                    text: modelData.status || qsTr("Unknown")
-                                    font.pixelSize: 11
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: root.textColorForBackground(baseColor, true)
-                                }
-                            }
-
-                            MouseArea {
+                            Rectangle {
                                 anchors.fill: parent
-                                hoverEnabled: true
-                                acceptedButtons: Qt.NoButton
-                                id: hoverArea
-                            }
+                                radius: 12
+                                color: baseColor
+                                border.color: Qt.darker(baseColor, 1.2)
+                                border.width: 1
 
-                            ToolTip.visible: hoverArea.containsMouse
-                            ToolTip.text: {
-                                var parts = [];
-                                if (displayName)
-                                    parts.push(displayName);
-                                if (repoName && repoName !== displayName)
-                                    parts.push(repoName);
-                                if (modelData.details)
-                                    parts.push(modelData.details);
-                                if (modelData.commit)
-                                    parts.push(qsTr("Commit %1").arg(modelData.commit));
-                                return parts.join("\n");
+                                Column {
+                                    anchors.centerIn: parent
+                                    width: parent.width - 24
+                                    spacing: 6
+
+                                    Label {
+                                        text: abbrev
+                                        font.bold: true
+                                        font.pixelSize: 28
+                                        color: root.textColorForBackground(baseColor, false)
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                        width: parent.width
+                                    }
+
+                                    Label {
+                                        text: displayName
+                                        font.pixelSize: 12
+                                        wrapMode: Label.WordWrap
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: root.textColorForBackground(baseColor, true)
+                                    }
+
+                                    Label {
+                                        text: modelData.status || qsTr("Unknown")
+                                        font.pixelSize: 11
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: root.textColorForBackground(baseColor, true)
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    acceptedButtons: Qt.NoButton
+                                    id: hoverArea
+                                }
+
+                                ToolTip.visible: hoverArea.containsMouse
+                                ToolTip.text: {
+                                    var parts = [];
+                                    if (displayName)
+                                        parts.push(displayName);
+                                    if (repoName && repoName !== displayName)
+                                        parts.push(repoName);
+                                    if (modelData.details)
+                                        parts.push(modelData.details);
+                                    if (modelData.commit)
+                                        parts.push(qsTr("Commit %1").arg(modelData.commit));
+                                    return parts.join("\n");
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
-        Label {
-            visible: submoduleModel.length === 0
-            text: qsTr("No submodules detected")
-            horizontalAlignment: Text.AlignHCenter
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            opacity: 0.6
+            Label {
+                visible: submoduleModel.length === 0
+                text: qsTr("No submodules detected")
+                horizontalAlignment: Text.AlignHCenter
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                opacity: 0.6
+            }
         }
     }
 }

--- a/qml/SubmoduleList.qml
+++ b/qml/SubmoduleList.qml
@@ -6,6 +6,124 @@ Frame {
     id: root
     property var submoduleModel: []
 
+    readonly property int cardSize: 140
+
+    function _stringToHash(value) {
+        var hash = 0;
+        if (!value)
+            value = "";
+        for (var i = 0; i < value.length; ++i) {
+            hash = ((hash << 5) - hash) + value.charCodeAt(i);
+            hash = hash & 0xffffffff;
+        }
+        return Math.abs(hash);
+    }
+
+    function colorFromString(value) {
+        var hash = _stringToHash(value);
+        var hue = hash % 360;
+        var saturation = 0.45 + ((hash >> 3) % 30) / 100;
+        var lightness = 0.55 + ((hash >> 6) % 20) / 100;
+        return Qt.hsla(hue / 360.0,
+                       Math.min(saturation, 0.8),
+                       Math.min(lightness, 0.8),
+                       1.0);
+    }
+
+    function textColorForBackground(color, subtle) {
+        var luminance = 0.299 * color.r + 0.587 * color.g + 0.114 * color.b;
+        if (subtle)
+            return luminance > 0.6 ? Qt.rgba(0, 0, 0, 0.65) : Qt.rgba(1, 1, 1, 0.7);
+        return luminance > 0.6 ? "#202020" : "#ffffff";
+    }
+
+    function _nextDistinctLetter(pool, preferVowel, used) {
+        if (!pool)
+            return "";
+        var vowels = "AEIOUY";
+        var vowelCandidate = "";
+        var consonantCandidate = "";
+        used = used || [];
+        for (var i = 0; i < pool.length; ++i) {
+            var ch = pool[i];
+            if (!(/[A-Za-z0-9]/).test(ch))
+                continue;
+            var upper = ch.toUpperCase();
+            if (used.indexOf(upper) !== -1)
+                continue;
+            if (vowels.indexOf(upper) !== -1) {
+                if (!vowelCandidate)
+                    vowelCandidate = upper;
+                if (preferVowel)
+                    return upper;
+            } else {
+                if (!consonantCandidate)
+                    consonantCandidate = upper;
+                if (!preferVowel)
+                    return upper;
+            }
+        }
+        return preferVowel ? (vowelCandidate || consonantCandidate) : (consonantCandidate || vowelCandidate);
+    }
+
+    function abbreviationForName(name) {
+        if (!name)
+            return "???";
+
+        var normalized = name.replace(/[^A-Za-z0-9]+/g, " ").trim();
+        if (!normalized.length)
+            normalized = name.replace(/[^A-Za-z0-9]/g, "");
+
+        var tokens = normalized.split(/\s+/).filter(function(token) { return token.length > 0; });
+        if (tokens.length === 0)
+            tokens = [name.replace(/[^A-Za-z0-9]/g, "")];
+
+        var used = [];
+        var letters = [];
+
+        function addLetter(letter) {
+            if (!letter)
+                return;
+            var upper = letter.toUpperCase();
+            if (used.indexOf(upper) === -1) {
+                letters.push(upper);
+                used.push(upper);
+            }
+        }
+
+        addLetter(tokens[0][0]);
+
+        if (tokens.length > 1)
+            addLetter(tokens[tokens.length - 1][0]);
+
+        if (tokens.length > 2) {
+            var middleIndex = Math.floor(tokens.length / 2);
+            if (middleIndex === tokens.length - 1)
+                middleIndex = Math.max(1, tokens.length - 2);
+            addLetter(tokens[middleIndex][0]);
+        } else {
+            var searchPool = tokens[0].slice(1);
+            if (tokens.length > 1)
+                searchPool += tokens[1].slice(1);
+            var preferred = _nextDistinctLetter(searchPool, true, used);
+            addLetter(preferred);
+        }
+
+        var combined = tokens.join("");
+        while (letters.length < 3) {
+            var preferVowel = letters.length === 1;
+            var next = _nextDistinctLetter(combined, preferVowel, used);
+            if (!next)
+                break;
+            addLetter(next);
+        }
+
+        while (letters.length < 3)
+            letters.push("?");
+
+        return letters.slice(0, 3).join("");
+    }
+
     ColumnLayout {
         anchors.fill: parent
         spacing: 8
@@ -19,45 +137,102 @@ Frame {
         ScrollView {
             Layout.fillWidth: true
             Layout.fillHeight: true
+            visible: submoduleModel.length > 0
+            clip: true
 
-            ListView {
-                model: submoduleModel
-                clip: true
-                spacing: 4
+            contentWidth: availableWidth
 
-                delegate: ItemDelegate {
-                    width: ListView.view.width
-                    contentItem: RowLayout {
-                        spacing: 12
-                        Label {
-                            text: modelData.path || modelData.raw
-                            Layout.fillWidth: true
-                            elide: Label.ElideRight
-                        }
-                        Label {
-                            text: modelData.status || qsTr("Unknown")
-                            color: "#ff9800"
-                        }
-                        Label {
-                            text: modelData.details ? modelData.details : ""
-                            color: palette.placeholderText
-                            elide: Label.ElideRight
-                            Layout.preferredWidth: 160
+            Item {
+                width: parent.width
+                implicitHeight: submoduleFlow.implicitHeight + 24
+                height: implicitHeight
+
+                Flow {
+                    id: submoduleFlow
+                    anchors.fill: parent
+                    anchors.margins: 12
+                    spacing: 12
+                    implicitHeight: childrenRect.height
+
+                    Repeater {
+                        model: submoduleModel
+
+                        delegate: Item {
+                        width: root.cardSize
+                        height: root.cardSize
+
+                        readonly property string repoLabel: modelData.path || modelData.raw || ""
+                        readonly property color baseColor: root.colorFromString(repoLabel)
+                        readonly property string abbrev: root.abbreviationForName(repoLabel)
+
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: 12
+                            color: baseColor
+                            border.color: Qt.darker(baseColor, 1.2)
+                            border.width: 1
+
+                            Column {
+                                anchors.centerIn: parent
+                                width: parent.width - 24
+                                spacing: 6
+
+                                Label {
+                                    text: abbrev
+                                    font.bold: true
+                                    font.pixelSize: 32
+                                    color: root.textColorForBackground(baseColor, false)
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                    width: parent.width
+                                }
+
+                                Label {
+                                    text: repoLabel
+                                    font.pixelSize: 12
+                                    wrapMode: Label.WordWrap
+                                    horizontalAlignment: Text.AlignHCenter
+                                    color: root.textColorForBackground(baseColor, true)
+                                }
+
+                                Label {
+                                    text: modelData.details ? modelData.details : ""
+                                    visible: text.length > 0
+                                    font.pixelSize: 11
+                                    wrapMode: Label.WordWrap
+                                    horizontalAlignment: Text.AlignHCenter
+                                    color: root.textColorForBackground(baseColor, true)
+                                }
+
+                                Label {
+                                    text: modelData.status || qsTr("Unknown")
+                                    font.pixelSize: 11
+                                    horizontalAlignment: Text.AlignHCenter
+                                    color: root.textColorForBackground(baseColor, true)
+                                }
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                acceptedButtons: Qt.NoButton
+                                id: hoverArea
+                            }
+
+                            ToolTip.visible: hoverArea.containsMouse
+                            ToolTip.text: modelData.commit ? qsTr("Commit %1").arg(modelData.commit) : (modelData.raw || repoLabel)
                         }
                     }
-                    ToolTip.visible: hovered
-                    ToolTip.text: modelData.commit ? qsTr("Commit %1").arg(modelData.commit) : (modelData.raw || "")
-                }
-
-                footer: Label {
-                    visible: submoduleModel.length === 0
-                    text: qsTr("No submodules detected")
-                    horizontalAlignment: Text.AlignHCenter
-                    width: ListView.view ? ListView.view.width : implicitWidth
-                    padding: 12
-                    opacity: 0.6
                 }
             }
+        }
+
+        Label {
+            visible: submoduleModel.length === 0
+            text: qsTr("No submodules detected")
+            horizontalAlignment: Text.AlignHCenter
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            opacity: 0.6
         }
     }
 }

--- a/qml/SubmoduleList.qml
+++ b/qml/SubmoduleList.qml
@@ -152,87 +152,88 @@ Frame {
                     anchors.fill: parent
                     anchors.margins: 12
                     spacing: 12
-                    implicitHeight: childrenRect.height
+                    //implicitHeight: childrenRect.height
 
                     Repeater {
                         model: submoduleModel
 
                         delegate: Item {
-                        width: root.cardSize
-                        height: root.cardSize
+                            width: root.cardSize
+                            height: root.cardSize
 
-                        readonly property string repoLabel: modelData.path || modelData.raw || ""
-                        readonly property color baseColor: root.colorFromString(repoLabel)
-                        readonly property string abbrev: root.abbreviationForName(repoLabel)
+                            readonly property string repoLabel: modelData.path || modelData.raw || ""
+                            readonly property color baseColor: root.colorFromString(repoLabel)
+                            readonly property string abbrev: root.abbreviationForName(repoLabel)
 
-                        Rectangle {
-                            anchors.fill: parent
-                            radius: 12
-                            color: baseColor
-                            border.color: Qt.darker(baseColor, 1.2)
-                            border.width: 1
-
-                            Column {
-                                anchors.centerIn: parent
-                                width: parent.width - 24
-                                spacing: 6
-
-                                Label {
-                                    text: abbrev
-                                    font.bold: true
-                                    font.pixelSize: 32
-                                    color: root.textColorForBackground(baseColor, false)
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    width: parent.width
-                                }
-
-                                Label {
-                                    text: repoLabel
-                                    font.pixelSize: 12
-                                    wrapMode: Label.WordWrap
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: root.textColorForBackground(baseColor, true)
-                                }
-
-                                Label {
-                                    text: modelData.details ? modelData.details : ""
-                                    visible: text.length > 0
-                                    font.pixelSize: 11
-                                    wrapMode: Label.WordWrap
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: root.textColorForBackground(baseColor, true)
-                                }
-
-                                Label {
-                                    text: modelData.status || qsTr("Unknown")
-                                    font.pixelSize: 11
-                                    horizontalAlignment: Text.AlignHCenter
-                                    color: root.textColorForBackground(baseColor, true)
-                                }
-                            }
-
-                            MouseArea {
+                            Rectangle {
                                 anchors.fill: parent
-                                hoverEnabled: true
-                                acceptedButtons: Qt.NoButton
-                                id: hoverArea
-                            }
+                                radius: 12
+                                color: baseColor
+                                border.color: Qt.darker(baseColor, 1.2)
+                                border.width: 1
 
-                            ToolTip.visible: hoverArea.containsMouse
-                            ToolTip.text: modelData.commit ? qsTr("Commit %1").arg(modelData.commit) : (modelData.raw || repoLabel)
+                                Column {
+                                    anchors.centerIn: parent
+                                    width: parent.width - 24
+                                    spacing: 6
+
+                                    Label {
+                                        text: abbrev
+                                        font.bold: true
+                                        font.pixelSize: 32
+                                        color: root.textColorForBackground(baseColor, false)
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                        width: parent.width
+                                    }
+
+                                    Label {
+                                        text: repoLabel
+                                        font.pixelSize: 12
+                                        wrapMode: Label.WordWrap
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: root.textColorForBackground(baseColor, true)
+                                    }
+
+                                    Label {
+                                        text: modelData.details ? modelData.details : ""
+                                        visible: text.length > 0
+                                        font.pixelSize: 11
+                                        wrapMode: Label.WordWrap
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: root.textColorForBackground(baseColor, true)
+                                    }
+
+                                    Label {
+                                        text: modelData.status || qsTr("Unknown")
+                                        font.pixelSize: 11
+                                        horizontalAlignment: Text.AlignHCenter
+                                        color: root.textColorForBackground(baseColor, true)
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    acceptedButtons: Qt.NoButton
+                                    id: hoverArea
+                                }
+
+                                ToolTip.visible: hoverArea.containsMouse
+                                ToolTip.text: modelData.commit ? qsTr("Commit %1").arg(modelData.commit) : (modelData.raw || repoLabel)
+                            }
                         }
                     }
                 }
             }
-        }
 
-        Label {
-            visible: submoduleModel.length === 0
-            text: qsTr("No submodules detected")
-            horizontalAlignment: Text.AlignHCenter
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            opacity: 0.6
+            Label {
+                visible: submoduleModel.length === 0
+                text: qsTr("No submodules detected")
+                horizontalAlignment: Text.AlignHCenter
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                opacity: 0.6
+            }
         }
     }
 }

--- a/qml/SubmoduleList.qml
+++ b/qml/SubmoduleList.qml
@@ -30,6 +30,24 @@ Frame {
                        1.0);
     }
 
+    function leafName(value) {
+        if (!value)
+            return "";
+
+        var normalized = value.replace(/\\/g, "/");
+        normalized = normalized.replace(/\/+$/, "");
+        if (!normalized.length)
+            return "";
+
+        var segments = normalized.split("/");
+        for (var i = segments.length - 1; i >= 0; --i) {
+            if (segments[i].length)
+                return segments[i];
+        }
+
+        return value;
+    }
+
     function textColorForBackground(color, subtle) {
         var luminance = 0.299 * color.r + 0.587 * color.g + 0.114 * color.b;
         if (subtle)
@@ -164,8 +182,9 @@ Frame {
                         height: root.cardSize
 
                         readonly property string repoName: modelData.name || modelData.path || modelData.raw || ""
-                        readonly property color baseColor: root.colorFromString(repoName)
-                        readonly property string abbrev: root.abbreviationForName(repoName, 5)
+                        readonly property string displayName: root.leafName(repoName)
+                        readonly property color baseColor: root.colorFromString(displayName || repoName)
+                        readonly property string abbrev: root.abbreviationForName(displayName || repoName, 5)
 
                         Rectangle {
                             anchors.fill: parent
@@ -190,7 +209,7 @@ Frame {
                                 }
 
                                 Label {
-                                    text: repoName
+                                    text: displayName
                                     font.pixelSize: 12
                                     wrapMode: Label.WordWrap
                                     horizontalAlignment: Text.AlignHCenter
@@ -215,7 +234,9 @@ Frame {
                             ToolTip.visible: hoverArea.containsMouse
                             ToolTip.text: {
                                 var parts = [];
-                                if (repoName)
+                                if (displayName)
+                                    parts.push(displayName);
+                                if (repoName && repoName !== displayName)
                                     parts.push(repoName);
                                 if (modelData.details)
                                     parts.push(modelData.details);

--- a/src/gitclientbackend.cpp
+++ b/src/gitclientbackend.cpp
@@ -387,9 +387,13 @@ void GitClientBackend::updateSubmodules()
             entry.insert("commit", QString::fromUtf8(oidStr));
         }
 
+        const char *submoduleName = git_submodule_name(sm);
+        if (submoduleName) {
+            entry.insert("name", QString::fromUtf8(submoduleName));
+        }
+
         unsigned int statusFlags = 0;
         git_repository *repo = git_submodule_owner(sm);
-        const char *submoduleName = git_submodule_name(sm);
         if (repo && submoduleName) {
             git_submodule_status(&statusFlags, repo, submoduleName, GIT_SUBMODULE_IGNORE_NONE);
         }


### PR DESCRIPTION
## Summary
- replace the submodule list view with a responsive panel of square tiles
- derive stable colors and human-friendly abbreviations for each submodule based on its name
- surface key status/details text inside each tile with improved tooltip handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4130e410832298de1deaeab10bd4