### PR TITLE
Add interactive commit history graph view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,14 @@ qt_add_qml_module(appGitGenius
         qml/RepositoryTreeNode.qml
         qml/RepositoryTreeView.qml
         qml/GitCommandDialog.qml
+        qml/CommitHistoryView.qml
     RESOURCES
         assets/icons/repository.svg
         assets/icons/branch.svg
         assets/icons/submodule.svg
     SOURCES
         src/gitclientbackend.h src/gitclientbackend.cpp
+        src/commithistorymodel.h src/commithistorymodel.cpp
         SOURCES
         SOURCES src/backend.h src/backend.cpp
 )

--- a/qml/CommitHistoryView.qml
+++ b/qml/CommitHistoryView.qml
@@ -1,0 +1,321 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Frame {
+    id: root
+    property alias model: historyList.model
+    property var branches: []
+    property string currentBranch: ""
+    property color mainlineColor: Qt.rgba(0.17, 0.48, 0.9, 1)
+    property color branchColor: Qt.rgba(0.54, 0.59, 0.63, 1)
+    property real laneSpacing: 28
+    property var expandedGroups: ({})
+
+    signal branchSelected(string branch)
+
+    padding: 12
+
+    function isGroupExpanded(key) {
+        return expandedGroups && expandedGroups[key];
+    }
+
+    function toggleGroup(key) {
+        if (!expandedGroups) {
+            expandedGroups = {};
+        }
+        const current = expandedGroups[key];
+        expandedGroups[key] = !current;
+        expandedGroups = Object.assign({}, expandedGroups);
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 12
+
+        RowLayout {
+            spacing: 12
+            Layout.fillWidth: true
+
+            Label {
+                text: qsTr("Branch")
+                font.bold: true
+            }
+
+            ComboBox {
+                id: branchSelector
+                Layout.preferredWidth: 220
+                model: root.branches
+                textRole: ""
+                onActivated: (index) => {
+                    if (index >= 0 && index < count) {
+                        const name = textAt(index)
+                        root.currentBranch = name
+                        root.branchSelected(name)
+                    }
+                }
+
+                Component.onCompleted: {
+                    const idx = root.branches.indexOf(root.currentBranch)
+                    if (idx >= 0) {
+                        currentIndex = idx
+                    }
+                }
+
+                onModelChanged: {
+                    const idx = root.branches.indexOf(root.currentBranch)
+                    if (idx >= 0) {
+                        currentIndex = idx
+                    }
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+        }
+
+        ListView {
+            id: historyList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            boundsBehavior: Flickable.StopAtBounds
+            spacing: 4
+            cacheBuffer: 480
+
+            delegate: Item {
+                id: delegateRoot
+                width: ListView.view.width
+                property bool groupExpanded: root.isGroupExpanded(groupKey)
+                property bool collapsible: groupSize > 1
+                property bool header: collapsible && groupIndex === 0
+                property bool collapsedMember: collapsible && groupIndex > 0 && !groupExpanded
+                property var lanesBeforeData: lanesBefore
+                property var lanesAfterData: lanesAfter
+                property var connectionsData: connections
+                property int laneValue: lane
+                property bool mainlineState: mainline
+
+                visible: !collapsedMember
+                implicitHeight: collapsedMember ? 0 : Math.max(contentItem.implicitHeight + 8, 76)
+
+                onLanesBeforeDataChanged: graphCanvas.requestPaint()
+                onLanesAfterDataChanged: graphCanvas.requestPaint()
+                onConnectionsDataChanged: graphCanvas.requestPaint()
+                onLaneValueChanged: graphCanvas.requestPaint()
+                onMainlineStateChanged: graphCanvas.requestPaint()
+
+                Rectangle {
+                    id: contentItem
+                    anchors.fill: parent
+                    color: "transparent"
+                    implicitHeight: graphContainer.implicitHeight + 12
+
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        spacing: 16
+
+                        Item {
+                            id: leftContainer
+                            Layout.fillWidth: laneValue < 0
+                            Layout.preferredWidth: laneValue < 0 ? 240 : 0
+                            visible: laneValue < 0
+                            implicitHeight: graphCanvas.implicitHeight
+
+                            ColumnLayout {
+                                id: leftColumn
+                                anchors.fill: parent
+                                anchors.right: parent.right
+                                spacing: 6
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 6
+                                    visible: true
+
+                                    ToolButton {
+                                        visible: header
+                                        text: header && groupExpanded ? "−" : "+"
+                                        font.bold: true
+                                        onClicked: root.toggleGroup(groupKey)
+                                    }
+
+                                    Text {
+                                        id: leftSummaryLabel
+                                        Layout.fillWidth: true
+                                        text: laneValue < 0 ? leftSummary : summary
+                                        textFormat: Text.PlainText
+                                        wrapMode: Text.Wrap
+                                        horizontalAlignment: Text.AlignRight
+                                        font.pointSize: 11
+                                    }
+                                }
+
+                                Text {
+                                    id: leftMeta
+                                    Layout.fillWidth: true
+                                    text: laneValue < 0 ? `${author} • ${relativeTime} • ${shortOid}` : ""
+                                    font.pointSize: 9
+                                    color: Qt.rgba(0.5, 0.55, 0.6, 1)
+                                    horizontalAlignment: Text.AlignRight
+                                    wrapMode: Text.NoWrap
+                                }
+                            }
+                        }
+
+                        Item {
+                            id: graphContainer
+                            Layout.preferredWidth: Math.max(220, (lanesBeforeData ? lanesBeforeData.length : 0) * root.laneSpacing + 80)
+                            Layout.minimumWidth: 220
+                            Layout.maximumWidth: 360
+                            Layout.fillHeight: true
+                            implicitHeight: Math.max((laneValue >= 0 ? textColumn.implicitHeight : leftColumn.implicitHeight) + 16, 84)
+
+                            Canvas {
+                                id: graphCanvas
+                                anchors.fill: parent
+                                antialiasing: true
+                                onPaint: {
+                                    const ctx = getContext("2d")
+                                    ctx.reset()
+                                    ctx.clearRect(0, 0, width, height)
+
+                                    function laneToX(value) {
+                                        return width / 2 + value * root.laneSpacing
+                                    }
+
+                                    const top = 0
+                                    const bottom = height
+                                    const mid = height / 2
+                                    const before = lanesBeforeData || []
+                                    const after = lanesAfterData || []
+                                    const edges = connectionsData || []
+
+                                    ctx.lineWidth = 2
+
+                                    ctx.strokeStyle = Qt.rgba(0.73, 0.75, 0.78, 1)
+                                    ctx.beginPath()
+                                    for (let i = 0; i < before.length; ++i) {
+                                        const laneId = before[i]
+                                        const x = laneToX(laneId)
+                                        ctx.moveTo(x, top)
+                                        ctx.lineTo(x, mid)
+                                    }
+                                    ctx.stroke()
+
+                                    ctx.beginPath()
+                                    for (let i = 0; i < after.length; ++i) {
+                                        const laneId = after[i]
+                                        const x = laneToX(laneId)
+                                        ctx.moveTo(x, mid)
+                                        ctx.lineTo(x, bottom)
+                                    }
+                                    ctx.stroke()
+
+                                    for (let i = 0; i < edges.length; ++i) {
+                                        const edge = edges[i]
+                                        const fromX = laneToX(edge.from)
+                                        const toX = laneToX(edge.to)
+                                        const color = edge.parentMainline ? root.mainlineColor : root.branchColor
+                                        ctx.strokeStyle = color
+                                        ctx.lineWidth = edge.parentMainline ? 3 : 2
+                                        ctx.beginPath()
+                                        if (edge.from === edge.to) {
+                                            ctx.moveTo(fromX, mid)
+                                            ctx.lineTo(toX, bottom)
+                                        } else {
+                                            const controlOffset = Math.min(Math.abs(toX - fromX) * 0.5, root.laneSpacing * 2)
+                                            ctx.moveTo(fromX, mid)
+                                            ctx.bezierCurveTo(fromX, mid + controlOffset, toX, mid + controlOffset, toX, bottom)
+                                        }
+                                        ctx.stroke()
+                                    }
+
+                                    const laneX = laneToX(laneValue)
+                                    ctx.fillStyle = delegateRoot.mainlineState ? root.mainlineColor : root.branchColor
+                                    ctx.beginPath()
+                                    ctx.arc(laneX, mid, 6, 0, Math.PI * 2)
+                                    ctx.fill()
+                                    ctx.lineWidth = 2
+                                    ctx.strokeStyle = "white"
+                                    ctx.stroke()
+                                }
+                                onWidthChanged: requestPaint()
+                                onHeightChanged: requestPaint()
+                            }
+                        }
+
+                        Item {
+                            id: rightContainer
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: laneValue >= 0 ? 320 : 0
+                            visible: laneValue >= 0
+                            implicitHeight: graphCanvas.implicitHeight
+
+                            ColumnLayout {
+                                id: textColumn
+                                anchors.fill: parent
+                                spacing: 6
+
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 6
+
+                                    ToolButton {
+                                        visible: header
+                                        text: header && groupExpanded ? "−" : "+"
+                                        font.bold: true
+                                        onClicked: root.toggleGroup(groupKey)
+                                    }
+
+                                    Text {
+                                        id: rightSummary
+                                        Layout.fillWidth: true
+                                        text: summary
+                                        textFormat: Text.PlainText
+                                        wrapMode: Text.Wrap
+                                        font.pointSize: 11
+                                    }
+                                }
+
+                                Text {
+                                    id: rightMeta
+                                    Layout.fillWidth: true
+                                    text: `${author} • ${relativeTime} • ${shortOid}`
+                                    font.pointSize: 9
+                                    color: Qt.rgba(0.5, 0.55, 0.6, 1)
+                                    wrapMode: Text.NoWrap
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: historyList.model
+        function onModelReset() {
+            root.expandedGroups = ({})
+        }
+    }
+
+    onCurrentBranchChanged: {
+        const idx = branches.indexOf(currentBranch)
+        if (idx >= 0) {
+            branchSelector.currentIndex = idx
+        }
+        expandedGroups = ({})
+    }
+
+    onBranchesChanged: {
+        const idx = branches.indexOf(currentBranch)
+        if (idx >= 0) {
+            branchSelector.currentIndex = idx
+        }
+    }
+}
+

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -65,6 +65,15 @@ ApplicationWindow {
         anchors.margins: 12
         spacing: 12
 
+        CommitHistoryView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: gitBackend.commitHistoryModel
+            branches: gitBackend.branches
+            currentBranch: gitBackend.currentBranch
+            onBranchSelected: gitBackend.setCurrentBranch(branch)
+        }
+
         StatusList {
             Layout.fillWidth: true
             Layout.fillHeight: true

--- a/src/commithistorymodel.cpp
+++ b/src/commithistorymodel.cpp
@@ -1,0 +1,529 @@
+#include "commithistorymodel.h"
+
+#include <QRegularExpression>
+#include <QtGlobal>
+
+#include <algorithm>
+
+#include <git2.h>
+
+namespace {
+QString oidToString(const git_oid &oid)
+{
+    char buffer[GIT_OID_HEXSZ + 1] = {0};
+    git_oid_tostr(buffer, sizeof(buffer), &oid);
+    return QString::fromUtf8(buffer);
+}
+
+QString shortOid(const git_oid &oid)
+{
+    char buffer[8] = {0};
+    git_oid_tostr(buffer, sizeof(buffer), &oid);
+    return QString::fromUtf8(buffer);
+}
+}
+
+CommitHistoryModel::CommitHistoryModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+int CommitHistoryModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid()) {
+        return 0;
+    }
+    return m_entries.size();
+}
+
+QVariant CommitHistoryModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_entries.size()) {
+        return {};
+    }
+
+    const CommitEntry &entry = m_entries.at(index.row());
+    switch (role) {
+    case OidRole:
+        return entry.oid;
+    case ShortOidRole:
+        return entry.shortOid;
+    case SummaryRole:
+        return entry.summary;
+    case LeftSummaryRole:
+        return entry.leftSummary;
+    case AuthorRole:
+        return entry.author;
+    case AuthorEmailRole:
+        return entry.authorEmail;
+    case TimestampRole:
+        return entry.timestamp;
+    case RelativeTimeRole:
+        return entry.relativeTime;
+    case ParentIdsRole:
+        return entry.parentIds;
+    case LaneRole:
+        return entry.laneValue;
+    case LanesBeforeRole: {
+        QVariantList values;
+        values.reserve(entry.lanesBefore.size());
+        for (int lane : entry.lanesBefore) {
+            values.append(lane);
+        }
+        return values;
+    }
+    case LanesAfterRole: {
+        QVariantList values;
+        values.reserve(entry.lanesAfter.size());
+        for (int lane : entry.lanesAfter) {
+            values.append(lane);
+        }
+        return values;
+    }
+    case ConnectionsRole: {
+        QVariantList values;
+        values.reserve(entry.connections.size());
+        for (const Connection &connection : entry.connections) {
+            QVariantMap map;
+            map.insert(QStringLiteral("from"), connection.fromLane);
+            map.insert(QStringLiteral("to"), connection.toLane);
+            map.insert(QStringLiteral("mainline"), connection.mainline);
+            map.insert(QStringLiteral("parentMainline"), connection.parentMainline);
+            values.append(map);
+        }
+        return values;
+    }
+    case IsMainlineRole:
+        return entry.mainline;
+    case GroupKeyRole:
+        return entry.groupKey;
+    case GroupSizeRole:
+        return entry.groupSize;
+    case GroupIndexRole:
+        return entry.groupIndex;
+    default:
+        return {};
+    }
+}
+
+QHash<int, QByteArray> CommitHistoryModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles.insert(OidRole, "oid");
+    roles.insert(ShortOidRole, "shortOid");
+    roles.insert(SummaryRole, "summary");
+    roles.insert(LeftSummaryRole, "leftSummary");
+    roles.insert(AuthorRole, "author");
+    roles.insert(AuthorEmailRole, "authorEmail");
+    roles.insert(TimestampRole, "timestamp");
+    roles.insert(RelativeTimeRole, "relativeTime");
+    roles.insert(ParentIdsRole, "parentIds");
+    roles.insert(LaneRole, "lane");
+    roles.insert(LanesBeforeRole, "lanesBefore");
+    roles.insert(LanesAfterRole, "lanesAfter");
+    roles.insert(ConnectionsRole, "connections");
+    roles.insert(IsMainlineRole, "mainline");
+    roles.insert(GroupKeyRole, "groupKey");
+    roles.insert(GroupSizeRole, "groupSize");
+    roles.insert(GroupIndexRole, "groupIndex");
+    return roles;
+}
+
+QStringList CommitHistoryModel::branches() const
+{
+    return m_branches;
+}
+
+QString CommitHistoryModel::currentBranch() const
+{
+    return m_currentBranch;
+}
+
+void CommitHistoryModel::setRepository(git_repository *repository)
+{
+    if (m_repository == repository) {
+        return;
+    }
+    m_repository = repository;
+    reload();
+}
+
+void CommitHistoryModel::setCurrentBranch(const QString &branchName)
+{
+    if (branchName == m_currentBranch) {
+        return;
+    }
+
+    if (!branchName.isEmpty() && !m_branches.contains(branchName)) {
+        return;
+    }
+
+    m_currentBranch = branchName;
+    emit currentBranchChanged();
+    collectCommits();
+}
+
+void CommitHistoryModel::reload()
+{
+    updateBranches();
+    collectCommits();
+}
+
+void CommitHistoryModel::updateBranches()
+{
+    QStringList branches;
+    if (!m_repository) {
+        if (m_branches != branches) {
+            m_branches = branches;
+            emit branchesChanged();
+        }
+        if (!m_currentBranch.isEmpty()) {
+            m_currentBranch.clear();
+            emit currentBranchChanged();
+        }
+        return;
+    }
+
+    git_branch_iterator *iterator = nullptr;
+    if (git_branch_iterator_new(&iterator, m_repository, GIT_BRANCH_LOCAL) != 0) {
+        return;
+    }
+
+    git_reference *ref = nullptr;
+    git_branch_t type;
+    while (git_branch_next(&ref, &type, iterator) == 0) {
+        const char *name = nullptr;
+        if (git_branch_name(&name, ref) == 0 && name) {
+            branches.append(QString::fromUtf8(name));
+        }
+        git_reference_free(ref);
+    }
+    git_branch_iterator_free(iterator);
+    branches.sort(Qt::CaseInsensitive);
+
+    if (branches != m_branches) {
+        m_branches = branches;
+        emit branchesChanged();
+    }
+
+    QString preferred = detectHeadBranch();
+    if (m_currentBranch.isEmpty()) {
+        if (!preferred.isEmpty() && branches.contains(preferred)) {
+            m_currentBranch = preferred;
+        } else if (branches.contains(QStringLiteral("main"))) {
+            m_currentBranch = QStringLiteral("main");
+        } else if (branches.contains(QStringLiteral("master"))) {
+            m_currentBranch = QStringLiteral("master");
+        } else if (!branches.isEmpty()) {
+            m_currentBranch = branches.front();
+        } else {
+            m_currentBranch.clear();
+        }
+        if (!m_currentBranch.isEmpty()) {
+            emit currentBranchChanged();
+        }
+    } else if (!branches.contains(m_currentBranch)) {
+        m_currentBranch.clear();
+        if (!preferred.isEmpty() && branches.contains(preferred)) {
+            m_currentBranch = preferred;
+        } else if (!branches.isEmpty()) {
+            m_currentBranch = branches.front();
+        }
+        emit currentBranchChanged();
+    }
+}
+
+void CommitHistoryModel::collectCommits()
+{
+    beginResetModel();
+    m_entries.clear();
+
+    if (!m_repository || m_currentBranch.isEmpty()) {
+        endResetModel();
+        return;
+    }
+
+    const QByteArray refName = QByteArrayLiteral("refs/heads/") + m_currentBranch.toUtf8();
+    git_reference *branchRef = nullptr;
+    if (git_reference_lookup(&branchRef, m_repository, refName.constData()) != 0) {
+        endResetModel();
+        return;
+    }
+
+    git_reference *resolvedRef = nullptr;
+    git_oid headOid = git_oid{};
+    if (git_reference_resolve(&resolvedRef, branchRef) == 0 && resolvedRef) {
+        const git_oid *target = git_reference_target(resolvedRef);
+        if (target) {
+            headOid = *target;
+        }
+    } else {
+        const git_oid *target = git_reference_target(branchRef);
+        if (target) {
+            headOid = *target;
+        }
+    }
+    git_reference_free(resolvedRef);
+    git_reference_free(branchRef);
+
+    if (git_oid_is_zero(&headOid)) {
+        endResetModel();
+        return;
+    }
+
+    QSet<QString> mainline;
+    computeMainline(headOid, mainline);
+
+    git_revwalk *walker = nullptr;
+    if (git_revwalk_new(&walker, m_repository) != 0) {
+        endResetModel();
+        return;
+    }
+    git_revwalk_sorting(walker, GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME);
+    if (git_revwalk_push_ref(walker, refName.constData()) != 0) {
+        git_revwalk_free(walker);
+        endResetModel();
+        return;
+    }
+
+    QVector<int> laneOrder;
+    QHash<QString, int> futureLanes;
+    m_nextLeft = true;
+
+    git_oid oid;
+    int processed = 0;
+    const int maxCommits = 2000;
+    while (processed < maxCommits && git_revwalk_next(&oid, walker) == 0) {
+        git_commit *commit = nullptr;
+        if (git_commit_lookup(&commit, m_repository, &oid) != 0) {
+            continue;
+        }
+
+        CommitEntry entry;
+        entry.oid = oidToString(oid);
+        entry.shortOid = shortOid(oid);
+
+        const char *summary = git_commit_summary(commit);
+        if (summary) {
+            entry.summary = QString::fromUtf8(summary);
+        }
+        entry.leftSummary = buildLeftSummary(entry.summary);
+
+        const git_signature *author = git_commit_author(commit);
+        if (author) {
+            if (author->name) {
+                entry.author = QString::fromUtf8(author->name);
+            }
+            if (author->email) {
+                entry.authorEmail = QString::fromUtf8(author->email);
+            }
+            entry.timestamp = author->when.time;
+        }
+        entry.relativeTime = formatRelativeTime(entry.timestamp);
+
+        const unsigned int parentCount = git_commit_parentcount(commit);
+        entry.parentIds.reserve(parentCount);
+        for (unsigned int i = 0; i < parentCount; ++i) {
+            const git_oid *parentOid = git_commit_parent_id(commit, i);
+            if (parentOid) {
+                entry.parentIds.append(oidToString(*parentOid));
+            }
+        }
+
+        entry.mainline = mainline.contains(entry.oid);
+        entry.groupKey = entry.summary.trimmed().toLower() + QLatin1Char('|') + entry.author.toLower();
+
+        QSet<int> used;
+        for (int lane : laneOrder) {
+            used.insert(lane);
+        }
+        for (auto it = futureLanes.cbegin(); it != futureLanes.cend(); ++it) {
+            used.insert(it.value());
+        }
+
+        int laneValue = 0;
+        if (futureLanes.contains(entry.oid)) {
+            laneValue = futureLanes.take(entry.oid);
+        } else if (entry.mainline) {
+            laneValue = 0;
+        } else {
+            laneValue = allocateLane(used);
+        }
+        if (!laneOrder.contains(laneValue)) {
+            laneOrder.append(laneValue);
+            std::sort(laneOrder.begin(), laneOrder.end());
+        }
+
+        entry.lanesBefore = laneOrder;
+        entry.laneValue = laneValue;
+
+        QVector<int> parentLanes;
+        parentLanes.reserve(entry.parentIds.size());
+        for (int i = 0; i < entry.parentIds.size(); ++i) {
+            const QString &parentId = entry.parentIds.at(i);
+            int parentLane = 0;
+            const bool parentMainline = mainline.contains(parentId);
+            if (futureLanes.contains(parentId)) {
+                parentLane = futureLanes.value(parentId);
+            } else if (parentMainline) {
+                parentLane = 0;
+            } else {
+                parentLane = allocateLane(used);
+            }
+            used.insert(parentLane);
+            futureLanes.insert(parentId, parentLane);
+            parentLanes.append(parentLane);
+
+            Connection connection;
+            connection.fromLane = laneValue;
+            connection.toLane = parentLane;
+            connection.mainline = entry.mainline;
+            connection.parentMainline = parentMainline;
+            entry.connections.append(connection);
+        }
+
+        QSet<int> futureUsed;
+        for (auto it = futureLanes.cbegin(); it != futureLanes.cend(); ++it) {
+            futureUsed.insert(it.value());
+        }
+        laneOrder = futureUsed.values().toVector();
+        std::sort(laneOrder.begin(), laneOrder.end());
+
+        entry.lanesAfter = laneOrder;
+
+        m_entries.append(entry);
+        ++processed;
+        git_commit_free(commit);
+    }
+
+    git_revwalk_free(walker);
+
+    // compute grouping information
+    QString lastKey;
+    int currentCount = 0;
+    QVector<int> indices;
+    for (int i = 0; i < m_entries.size(); ++i) {
+        CommitEntry &entry = m_entries[i];
+        if (entry.groupKey == lastKey) {
+            ++currentCount;
+        } else {
+            for (int index : indices) {
+                m_entries[index].groupSize = currentCount;
+            }
+            indices.clear();
+            lastKey = entry.groupKey;
+            currentCount = 1;
+        }
+        entry.groupIndex = currentCount - 1;
+        indices.append(i);
+    }
+    for (int index : indices) {
+        m_entries[index].groupSize = currentCount;
+    }
+
+    endResetModel();
+}
+
+void CommitHistoryModel::computeMainline(const git_oid &headOid, QSet<QString> &outMainline) const
+{
+    git_oid current = headOid;
+    while (!git_oid_is_zero(&current)) {
+        git_commit *commit = nullptr;
+        if (git_commit_lookup(&commit, m_repository, &current) != 0) {
+            break;
+        }
+        outMainline.insert(oidToString(current));
+        if (git_commit_parentcount(commit) == 0) {
+            git_commit_free(commit);
+            break;
+        }
+        const git_oid *parent = git_commit_parent_id(commit, 0);
+        if (!parent) {
+            git_commit_free(commit);
+            break;
+        }
+        current = *parent;
+        git_commit_free(commit);
+    }
+}
+
+QString CommitHistoryModel::detectHeadBranch() const
+{
+    if (!m_repository) {
+        return {};
+    }
+    git_reference *head = nullptr;
+    if (git_repository_head(&head, m_repository) != 0) {
+        return {};
+    }
+    QString result;
+    if (git_reference_is_branch(head)) {
+        const char *shorthand = git_reference_shorthand(head);
+        if (shorthand) {
+            result = QString::fromUtf8(shorthand);
+        }
+    }
+    git_reference_free(head);
+    return result;
+}
+
+int CommitHistoryModel::allocateLane(QSet<int> &usedLanes)
+{
+    int candidate = 0;
+    if (m_nextLeft) {
+        candidate = -1;
+        while (usedLanes.contains(candidate)) {
+            --candidate;
+        }
+    } else {
+        candidate = 1;
+        while (usedLanes.contains(candidate)) {
+            ++candidate;
+        }
+    }
+    m_nextLeft = !m_nextLeft;
+    usedLanes.insert(candidate);
+    return candidate;
+}
+
+QString CommitHistoryModel::formatRelativeTime(qint64 timestamp)
+{
+    if (timestamp == 0) {
+        return {};
+    }
+    QDateTime commitTime = QDateTime::fromSecsSinceEpoch(timestamp, Qt::UTC).toLocalTime();
+    const QDateTime now = QDateTime::currentDateTime();
+    qint64 seconds = commitTime.secsTo(now);
+    if (seconds < 0) {
+        seconds = 0;
+    }
+    if (seconds < 60) {
+        return QObject::tr("Just now");
+    }
+    if (seconds < 3600) {
+        return QObject::tr("%1 minutes ago").arg(seconds / 60);
+    }
+    if (seconds < 86400) {
+        return QObject::tr("%1 hours ago").arg(seconds / 3600);
+    }
+    if (seconds < 86400 * 7) {
+        return QObject::tr("%1 days ago").arg(seconds / 86400);
+    }
+    return commitTime.toString(Qt::DefaultLocaleShortDate);
+}
+
+QString CommitHistoryModel::buildLeftSummary(const QString &summary)
+{
+    const QRegularExpression pattern(QStringLiteral("^(?:#?)(\\d+)\\s+(.*)$"), QRegularExpression::DotMatchesEverythingOption);
+    const QRegularExpressionMatch match = pattern.match(summary.trimmed());
+    if (!match.hasMatch()) {
+        return summary;
+    }
+    const QString number = match.captured(1);
+    const QString rest = match.captured(2).trimmed();
+    if (rest.isEmpty()) {
+        return summary;
+    }
+    return rest + QStringLiteral(" (#%1)").arg(number);
+}
+

--- a/src/commithistorymodel.h
+++ b/src/commithistorymodel.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QHash>
+#include <QSet>
+#include <QStringList>
+#include <QVector>
+
+struct git_repository;
+struct git_oid;
+
+class CommitHistoryModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QStringList branches READ branches NOTIFY branchesChanged FINAL)
+    Q_PROPERTY(QString currentBranch READ currentBranch WRITE setCurrentBranch NOTIFY currentBranchChanged FINAL)
+
+public:
+    enum Roles {
+        OidRole = Qt::UserRole + 1,
+        ShortOidRole,
+        SummaryRole,
+        LeftSummaryRole,
+        AuthorRole,
+        AuthorEmailRole,
+        TimestampRole,
+        RelativeTimeRole,
+        ParentIdsRole,
+        LaneRole,
+        LanesBeforeRole,
+        LanesAfterRole,
+        ConnectionsRole,
+        IsMainlineRole,
+        GroupKeyRole,
+        GroupSizeRole,
+        GroupIndexRole
+    };
+
+    explicit CommitHistoryModel(QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    QStringList branches() const;
+    QString currentBranch() const;
+
+    void setRepository(git_repository *repository);
+    Q_INVOKABLE void setCurrentBranch(const QString &branchName);
+    void reload();
+
+signals:
+    void branchesChanged();
+    void currentBranchChanged();
+
+private:
+    struct Connection {
+        int fromLane = 0;
+        int toLane = 0;
+        bool mainline = false;
+        bool parentMainline = false;
+    };
+
+    struct CommitEntry {
+        QString oid;
+        QString shortOid;
+        QString summary;
+        QString leftSummary;
+        QString author;
+        QString authorEmail;
+        qint64 timestamp = 0;
+        QString relativeTime;
+        QStringList parentIds;
+        QVector<int> lanesBefore;
+        QVector<int> lanesAfter;
+        QVector<Connection> connections;
+        int laneValue = 0;
+        bool mainline = false;
+        QString groupKey;
+        int groupSize = 1;
+        int groupIndex = 0;
+    };
+
+    void updateBranches();
+    void collectCommits();
+    void computeMainline(const git_oid &headOid, QSet<QString> &outMainline) const;
+    QString detectHeadBranch() const;
+    int allocateLane(QSet<int> &usedLanes);
+    static QString formatRelativeTime(qint64 timestamp);
+    static QString buildLeftSummary(const QString &summary);
+
+    git_repository *m_repository = nullptr;
+    QStringList m_branches;
+    QString m_currentBranch;
+    QVector<CommitEntry> m_entries;
+    bool m_nextLeft = true;
+};
+

--- a/src/gitclientbackend.h
+++ b/src/gitclientbackend.h
@@ -6,6 +6,8 @@
 #include <QVariantList>
 #include <QUrl>
 
+class CommitHistoryModel;
+
 struct git_repository;
 
 struct GitCommandResult
@@ -22,6 +24,9 @@ class GitClientBackend : public QObject
     Q_PROPERTY(QString repositoryPath READ repositoryPath NOTIFY repositoryPathChanged FINAL)
     Q_PROPERTY(QVariantList status READ status NOTIFY statusChanged FINAL)
     Q_PROPERTY(QVariantList submodules READ submodules NOTIFY submodulesChanged FINAL)
+    Q_PROPERTY(QStringList branches READ branches NOTIFY branchesChanged FINAL)
+    Q_PROPERTY(QString currentBranch READ currentBranch WRITE setCurrentBranch NOTIFY currentBranchChanged FINAL)
+    Q_PROPERTY(QObject *commitHistoryModel READ commitHistoryModel CONSTANT)
 
 public:
     explicit GitClientBackend(QObject *parent = nullptr);
@@ -30,17 +35,23 @@ public:
     QString repositoryPath() const;
     QVariantList status() const;
     QVariantList submodules() const;
+    QStringList branches() const;
+    QString currentBranch() const;
+    QObject *commitHistoryModel() const;
 
     Q_INVOKABLE bool openRepository(const QUrl &url);
     Q_INVOKABLE void refreshRepository();
     Q_INVOKABLE QVariantMap runCustomCommand(const QStringList &arguments);
     Q_INVOKABLE bool stageFiles(const QStringList &files);
     Q_INVOKABLE bool commit(const QString &message);
+    Q_INVOKABLE void setCurrentBranch(const QString &branchName);
 
 signals:
     void repositoryPathChanged();
     void statusChanged();
     void submodulesChanged();
+    void branchesChanged();
+    void currentBranchChanged();
     void commandExecuted(const QVariantMap &result);
 
 private:
@@ -52,4 +63,5 @@ private:
     QVariantList m_status;
     QVariantList m_submodules;
     git_repository *m_repository = nullptr;
+    CommitHistoryModel *m_commitHistoryModel = nullptr;
 };


### PR DESCRIPTION
## Summary
- introduce a CommitHistoryModel that exposes branch lists and pre-computed lane metadata for rendering
- add a CommitHistoryView QML component with a virtualized, collapsible commit graph and branch selector
- integrate the new history view into the main window and refresh it on backend git operations

## Testing
- cmake -S . -B build *(fails: missing bundled libgit2 CMake build files and Qt6 development packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5ba6c4908322a68dd218fed4ee43